### PR TITLE
bug in stl-map

### DIFF
--- a/RubeusCore/Game/user_init.cpp
+++ b/RubeusCore/Game/user_init.cpp
@@ -19,7 +19,7 @@
 
 std::string startupLevel = "play_level";
 
-play_level * playLevel = new play_level("play_level");
+/*play_level * playLevel = new play_level("play_level");
 
 paddle * leftPaddle = new paddle("left_paddle", "play_level", 0.0f, 0.0f, 0.5f, 3.0f,
 								 "Assets/debug.png", true,
@@ -41,3 +41,4 @@ ball * Ball = new ball("ball", "play_level", 8.0f, 4.5f, 0.5f, 0.5f,
 					   new Rubeus::Awerere::ABoxCollider(RML::Vector3D(8.0f, 4.5f, 1.0f),
 														 RML::Vector3D(8.5f, 5.0f, 1.0f)),
 					   true);
+*/

--- a/RubeusCore/Include/logger_component.h
+++ b/RubeusCore/Include/logger_component.h
@@ -9,10 +9,18 @@
 #include <iostream>
 #include <string.h>
 #include <string>
-
+#include <map>
 #include <GL/glew.h>
 #include <IL/il.h>
 #include <IL/ilu.h>
+
+
+class ColorCoder{
+    public: //For testing
+    static std::map<std::string, short> foregroundColorMap;
+    static std::map<std::string, short> backgroundColorMap;
+    static std::map<std::string, std::string> severityMap;
+};
 
  // TODO: Remove logger before shipping
 
@@ -68,7 +76,7 @@
 // In case the build configuration is not "Debug"
 
 // Deprecated for non-debug builds
-#define LOG(x) std::cout << x << std::endl;
+#define LOG(x) std::cout  << "\033[1;" << ColorCoder::foregroundColorMap["yellow"] << "m" << x << "\033[0m" << std::endl;
 
 // Deprecated for non-debug builds
 #define LOGEXTENDED(x) LOG(x)

--- a/RubeusCore/Source/logger_component.cpp
+++ b/RubeusCore/Source/logger_component.cpp
@@ -31,3 +31,28 @@ void DevILClearError()
 	while (ilGetError() != IL_NO_ERROR)
 		;
 }
+std::map<std::string, short> ColorCoder::foregroundColorMap={
+    {"black"     ,   30},
+    {"red"       ,   31},
+    {"green"     ,   32},
+    {"yellow"    ,   33},
+    {"blue"      ,   34},
+    {"magenta"   ,   35},
+    {"cyan"      ,   36},
+    {"white"     ,   37}
+};
+std::map<std::string, short> ColorCoder::backgroundColorMap={
+    {"black"     ,   40},
+    {"red"       ,   41},
+    {"green"     ,   42},
+    {"yellow"    ,   43},
+    {"blue"      ,   44},
+    {"magenta"   ,   45},
+    {"cyan"      ,   46},
+    {"white"     ,   47}
+};
+std::map<std::string, std::string> ColorCoder::severityMap={
+    {"ERROR"     ,   "red"},
+    {"ASSERT"    ,   "yellow"},
+    {"SUCCESS"   ,   "green"}
+};


### PR DESCRIPTION
Master HEAD: 6d9d0ddd53650a509acbad3d759df9c115d969e5
OS version: Kubuntu 18.10
CPU/GPU: Intel Core i7 2.2Hz/Nvidia GTX 1060 6 GB
Issue Presentation Code:
RubeusCore/include/logger_component.h:79
```
#define LOG(x) std::cout  << "\033[1;" << ColorCoder::foregroundColorMap["yellow"] << "m" << x << "\033[0m" << std::endl;
```
adding this line creates a segfault